### PR TITLE
fix errors on parsing

### DIFF
--- a/m2d
+++ b/m2d
@@ -6,6 +6,7 @@ import jinja2
 import codecs
 from optparse import OptionParser
 import re
+import mdx_slider
 
 parser = OptionParser()
 parser.add_option("-p", "--plain", action="store_true", dest="plain",

--- a/mdx_slider.py
+++ b/mdx_slider.py
@@ -1,11 +1,11 @@
 import markdown
-from markdown import etree
+from markdown import etree_loader
 import sys
 from elementtree.ElementTree import Element, SubElement, dump
 
 class SlideProcessor(markdown.treeprocessors.Treeprocessor):
     def create_slide(self, buf, i):
-        cont = etree.Element('div')
+        cont = etree_loader.importETree().Element('div')
         cont.set('class', 'slide')
         cont.set('id', str(i))
         i += 1
@@ -15,7 +15,7 @@ class SlideProcessor(markdown.treeprocessors.Treeprocessor):
 
     def create_source(self, root):
         if root.tag == 'img' and str(root.get('src'))[:4] == 'http':
-            src = etree.Element('cite')
+            src = etree_loader.importETree().Element('cite')
             src.text = 'Quelle: ' + str(root.get('src'))
             src.set('class', 'source')
             root.append(src)
@@ -49,7 +49,7 @@ class SlideProcessor(markdown.treeprocessors.Treeprocessor):
         if len(buf) > 0:
             nodes.append(self.create_slide(buf,i))
 
-        slide = etree.Element('div')
+        slide = etree_loader.importETree().Element('div')
         for n in nodes:
             slide.append(n)
         return slide


### PR DESCRIPTION
In my environment (python 2.6.6, markdown 2.0), your original code did not work.

I made some patches, but I am not sure these changes are correct, because I am a poor pythonista.
